### PR TITLE
Wip improve margin

### DIFF
--- a/core/lomas_core/models/collections.py
+++ b/core/lomas_core/models/collections.py
@@ -113,6 +113,7 @@ class ColumnMetadata(BaseModel):
     max_partition_length: Annotated[int, Field(gt=0)] | None = None
     max_influenced_partitions: Annotated[int, Field(gt=0)] | None = None
     max_partition_contributions: Annotated[int, Field(gt=0)] | None = None
+    public_info: Literal["keys", "lengths"] | None = None
 
 
 class StrMetadata(ColumnMetadata):

--- a/server/lomas_server/dp_queries/dp_libraries/opendp.py
+++ b/server/lomas_server/dp_queries/dp_libraries/opendp.py
@@ -111,7 +111,6 @@ def get_global_params(metadata: dict) -> dict:
         dict: Parameters for margin
     """
     margin_params = {}
-    margin_params["max_num_partitions"] = 1
     margin_params["max_partition_length"] = metadata["rows"]
 
     return margin_params
@@ -126,8 +125,7 @@ def multiple_group_update_params(metadata: dict, by_config: list, margin_params:
         by_config (list): List of columns used for grouping.
         margin_params (dict): Current parameters dictionary to update.
     """
-    # Initialize max_numpartitions/max_partition_length to 1
-    margin_params["max_num_partitions"] = 1
+    # Initialize max_partition_length to 1
     margin_params["max_partition_length"] = metadata["rows"]
 
     for column in by_config:
@@ -153,9 +151,13 @@ def multiple_group_update_params(metadata: dict, by_config: list, margin_params:
         # max_num_partitions logic:
         # We multiply the cardinality defined in each column
         # If None are defined, max_num_partitions is equal to None
+        # if "cardinality" in series_info:
+        #     if series_info["cardinality"]:
+        #         margin_params["max_num_partitions"] *= series_info["cardinality"]
         if "cardinality" in series_info:
-            if series_info["cardinality"]:
-                margin_params["max_num_partitions"] *= series_info["cardinality"]
+            margin_params["max_num_partitions"] = (
+                margin_params.get("max_num_partitions", 1) * series_info["cardinality"]
+            )
 
         # max_influenced_partitions logic:
         # We multiply the max_influenced_partitions defined in each column

--- a/server/lomas_server/dp_queries/dp_libraries/opendp.py
+++ b/server/lomas_server/dp_queries/dp_libraries/opendp.py
@@ -45,6 +45,43 @@ def get_lf_domain(metadata_dict: dict, plan: pl.LazyFrame) -> dp.mod.Domain:
     Returns:
         dp.mod.Domain: The OpenDP domain for the metadata.
     """
+
+    # Get raw lf domain (without margins)
+    raw_lf_domain = get_raw_lf_domain(metadata_dict)
+
+    # Add global margin to domain (for by=[])
+    lf_domain = add_global_margin(raw_lf_domain, metadata_dict)
+
+    # Add group-by margin (if Any)
+    margin_params = get_global_params(metadata_dict)
+
+    # If grouping in the query, we update the margin params
+    by_config = extract_group_by_columns(plan.explain())
+    if len(by_config) >= 1:
+        public_info = None
+        margin_params = multiple_group_update_params(metadata_dict, by_config, margin_params)
+        public_info = get_public_info(metadata_dict, by_config)
+
+        # TODO 323: Multiple margins?
+        # What if two group_by's in one query?
+        # Update margin with group_margin
+        lf_domain = dp.domains.with_margin(
+            lf_domain,
+            by=by_config,
+            public_info=public_info,
+            **margin_params,
+        )
+
+    return lf_domain
+
+
+def get_raw_lf_domain(metadata_dict: dict):
+    """
+    Builds the "raw" lf domain from the metadata.
+
+    The domain in considered "raw" because it does not contain any margin.
+    The domain is built by putting together series domains from each column.
+    """
     series_domains = []
     # Series domains
     for name, series_info in metadata_dict["columns"].items():
@@ -78,27 +115,21 @@ def get_lf_domain(metadata_dict: dict, plan: pl.LazyFrame) -> dp.mod.Domain:
         )
         series_domains.append(series_domain)
 
-    # Margins
-    # TODO 400: Check lengths vs. keys for public info
-    # https://docs.opendp.org/en/stable/getting-started/tabular-data/grouping.html
+    # Build domain from series domain
+    raw_lf_domain = dp.domains.lazyframe_domain(series_domains)
 
-    # Global margin parameters
-    margin_params = get_global_params(metadata_dict)
+    return raw_lf_domain
 
-    # If grouping in the query, we update the margin params
-    by_config = extract_group_by_columns(plan.explain())
-    if len(by_config) >= 1:
-        margin_params = multiple_group_update_params(metadata_dict, by_config, margin_params)
 
-    # TODO 323: Multiple margins?
-    # What if two group_by's in one query?
+def add_global_margin(lf_domain, metadata: dict):
+    """Builds the "global" (by = []) margin from the metadata"""
     lf_domain = dp.domains.with_margin(
-        dp.domains.lazyframe_domain(series_domains),
-        by=by_config,
-        public_info="keys",
-        **margin_params,
+        lf_domain,
+        by=[],
+        public_info="lengths",
+        max_partition_length=metadata["rows"],
+        # max_partition_contributions already managed in the input_distance
     )
-
     return lf_domain
 
 
@@ -191,6 +222,42 @@ def multiple_group_update_params(metadata: dict, by_config: list, margin_params:
             margin_params.get("max_partition_contributions"),
         )
     return margin_params
+
+
+def get_public_info(metadata_dict: dict, by_config: list) -> str:
+    """
+    Determine the most restrictive `public_info` level across a set of grouping columns.
+
+    The hierarchy of restriction is defined as:
+        None > "keys" > "lengths"
+
+    - If any column has `public_info` set to None, the result is None.
+    - If all columns have "lengths", the result is "lengths".
+    - If at least one column has "keys" (and none have None), the result is "keys".
+
+    Args:
+        metadata_dict (dict): The metadata dictionary
+        by_config (list): List of columns used for grouping.
+
+    Returns:
+        str: public_info type
+    """
+
+    public_info = "lengths"
+    # Key idea: None > keys > lengths
+    for col in by_config:
+        col_public_info = metadata_dict["columns"][col]["public_info"]
+
+        # If public_info is not set for one of the grouping column, we set it to None
+        if col_public_info is None:
+            public_info = None
+            break
+        # If any column has "keys", we downgrade to "keys"
+        # If all columns are lengths, public_info stays "lengths"
+        if col_public_info == "keys" and public_info == "lengths":
+            public_info = "keys"
+
+    return public_info
 
 
 class OpenDPQuerier(DPQuerier[OpenDPRequestModel, OpenDPQueryModel, OpenDPQueryResult]):
@@ -416,7 +483,11 @@ def reconstruct_measurement_pipeline(query_json: OpenDPQueryModel, metadata: dic
         lf_domain = get_lf_domain(metadata, plan)
 
         opendp_pipe = dp.measurements.make_private_lazyframe(
-            lf_domain, dp.metrics.symmetric_distance(), output_measure, plan
+            lf_domain,
+            dp.metrics.symmetric_distance(),
+            output_measure,
+            plan,
+            threshold=100,
         )
     else:
         raise InternalServerException(f"Unsupported OpenDP pipeline type: {query_json.pipeline_type}")

--- a/server/lomas_server/tests/test_api_opendp_polars.py
+++ b/server/lomas_server/tests/test_api_opendp_polars.py
@@ -271,7 +271,7 @@ class TestOpenDPpolarsFunctions(unittest.TestCase):
         metadata = Metadata.model_validate(RAW_METADATA).model_dump()
         by_config = ["column_int"]
         margin_params = get_global_params(metadata)
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
 
         # Since no max_partition length: rows is taken
         # Since no max_num_partitions: cardinality is taken
@@ -280,25 +280,36 @@ class TestOpenDPpolarsFunctions(unittest.TestCase):
 
         # max_partition_length is given: then we use it instead of rows
         metadata["columns"]["column_int"]["max_partition_length"] = 50
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin["max_partition_length"] = 50
         assert margin_params == expected_margin
 
         metadata["columns"]["column_int"]["max_influenced_partitions"] = 1
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin["max_influenced_partitions"] = 1
         assert margin_params == expected_margin
 
         metadata["columns"]["column_int"]["max_partition_contributions"] = 1
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin["max_partition_contributions"] = 1
         assert margin_params == expected_margin
 
         # Minimum between max_ids and max_partition_contributions should be taken
         metadata["columns"]["column_int"]["max_partition_contributions"] = 4
         metadata["max_ids"] = 2
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin["max_partition_contributions"] = 2
+        assert margin_params == expected_margin
+
+        # Check that only max_partition_length is used when no info on other parameters
+        new_col_int = {"type": "int", "precision": 32, "upper": 10, "lower": 1}
+        RAW_METADATA["columns"]["new_col_int"] = new_col_int  # type: ignore[index]
+        metadata = Metadata.model_validate(RAW_METADATA).model_dump()
+        by_config = ["new_col_int"]
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
+        # Since no cardinality or any other margin parameters, only max_partition_length is kept (from global parameter
+        # Max_partition_length = rows = 100
+        expected_margin = {"max_partition_length": 100}
         assert margin_params == expected_margin
 
     def test2_margin_grouping(self) -> None:
@@ -313,7 +324,7 @@ class TestOpenDPpolarsFunctions(unittest.TestCase):
         metadata = Metadata.model_validate(RAW_METADATA).model_dump()
         by_config = ["column_int", "new_col"]
         metadata["columns"]["column_int"]["max_partition_length"] = None
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin = {
             "max_num_partitions": 4,  # from col_int cardinality
             "max_partition_length": 100,  # since all are none, rows taken
@@ -322,7 +333,7 @@ class TestOpenDPpolarsFunctions(unittest.TestCase):
 
         metadata["columns"]["column_int"]["max_partition_length"] = 30
         metadata["columns"]["new_col"]["max_partition_length"] = 50
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin["max_partition_length"] = 30  # min between two col
         assert margin_params == expected_margin
 
@@ -330,13 +341,13 @@ class TestOpenDPpolarsFunctions(unittest.TestCase):
         metadata["max_ids"] = 20
         metadata["columns"]["column_int"]["max_influenced_partitions"] = 3
         metadata["columns"]["new_col"]["max_influenced_partitions"] = 5
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin["max_influenced_partitions"] = 15
         assert margin_params == expected_margin
 
         # Should never be bigger than max_ids global
         metadata["max_ids"] = 10
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin["max_influenced_partitions"] = 10
         assert margin_params == expected_margin
 
@@ -345,7 +356,7 @@ class TestOpenDPpolarsFunctions(unittest.TestCase):
         RAW_METADATA["columns"]["new_col_str"] = new_col_str  # type: ignore[index]
         metadata = Metadata.model_validate(RAW_METADATA).model_dump()  # max_ids = 1
         by_config = ["column_int", "new_col_str"]
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         # Since card1 = 4 and card2 = 2, card_tot = 8
         expected_margin = {
             "max_num_partitions": 8,
@@ -358,13 +369,13 @@ class TestOpenDPpolarsFunctions(unittest.TestCase):
         metadata["max_ids"] = 10
         metadata["columns"]["column_int"]["max_partition_contributions"] = 5
         metadata["columns"]["new_col"]["max_partition_contributions"] = 4
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin["max_partition_contributions"] = 5
         assert margin_params == expected_margin
 
         # Check max_partition_contributions (should never be bigger than max_ids)
         metadata["max_ids"] = 2
-        margin_params = multiple_group_update_params(metadata, by_config, margin_params)
+        margin_params = multiple_group_update_params(metadata, by_config, get_global_params(metadata))
         expected_margin["max_partition_contributions"] = 2
         assert margin_params == expected_margin
 

--- a/server/lomas_server/tests/test_api_opendp_polars.py
+++ b/server/lomas_server/tests/test_api_opendp_polars.py
@@ -8,6 +8,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from opendp import measures as ms
 
+# from opendp.extras.polars import dp_len
 from lomas_core.error_handler import (
     InvalidQueryException,
 )
@@ -98,7 +99,12 @@ def group_query_serialized(lf: pl.LazyFrame) -> str:
     Returns:
         str: The serialized plan of the grouped mean query in JSON format.
     """
-    plan = lf.group_by("sex").agg([pl.col("income").dp.mean(bounds=(1000, 100000), scale=(100_000.0, 1))])
+    plan = lf.group_by("sex").agg(
+        [
+            pl.col("income").dp.mean(bounds=(1000, 100000), scale=(100_000.0, 1)),
+            #    dp_len(scale=1.0)
+        ]
+    )
 
     return plan.serialize(format="json")
 

--- a/server/lomas_server/tests/test_data/metadata/covid_synthetic_metadata.yaml
+++ b/server/lomas_server/tests/test_data/metadata/covid_synthetic_metadata.yaml
@@ -14,6 +14,7 @@ columns:
     upper: 2000
   date:
     type: string
+    public_info: "keys"
     # TODO: opendp 0.12
     # type: datetime
     # lower: "2022-08-01"

--- a/server/lomas_server/tests/test_data/metadata/fso_income_synthetic_metadata.yaml
+++ b/server/lomas_server/tests/test_data/metadata/fso_income_synthetic_metadata.yaml
@@ -36,6 +36,7 @@ columns:
     precision: 32
     cardinality: 2 # Added by Lomas
     categories: [1, 2]
+    public_info: "keys"
     max_partition_length : 1_397_824
     # max_influenced_partitions: 1
     # max_partition_contributions: 1


### PR DESCRIPTION
# Done

* margin global is now always used (grouping or not)
* margin for grouping added in addition to global (if necessary)
* max_num_partitions (set to None by default, check cardinality if necessary in grouping)
* added new tests
* public_info added in ColumnMetadata model ("lengths","keys" or None). If no public_info are specified in the metadata of a given column, None will be used (higher privacy). public_info set to "lengths" at the global level since we always have the number of rows.
* public_info logic: if multiple group_by with different public_info, hierarchical choice between None > "keys" > "lengths"

# WIP
When grouping on column with public_info = None, a threshold must be setup for make_private_lazyframe, this has multiple consequences:
* need to setup an appropriate threshold: according the the documentation `OpenDP calibrates the filtering threshold such that the probability of releasing a partition with one individual is no greater than the privacy parameter delta (δ).` This is done by opendp when using the `context` feature. ==> we need to implement the same logic in Lomas
* if threshold setup, the query must be adapted and contains dp.len() in the aggregation. See https://github.com/opendp/opendp/blob/4ace93e09aef95f4e194f20cae7efa57cff71906/rust/src/measurements/make_private_lazyframe/group_by/matching.rs#L181
* this has also consequences on the mechanism used: `MakeMeasurement("key-sets cannot be privatized under "ZeroConcentratedDivergence". Approximate-DP is necessary.")`. For now, we only use either "max_divergence" or "zero_concentrated_divergence". See: https://github.com/dscc-admin-ch/lomas/blob/develop/server/lomas_server/constants.py#L97-L100