### PR TITLE
Adapt Doc Trigger to Nix Env

### DIFF
--- a/.github/workflows/push_readthedocs.yml
+++ b/.github/workflows/push_readthedocs.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [develop, master]
   push:
-    branches: [develop, master]
+    branches: [develop, master, trigger-doc]
   release:
     types: [published]
 

--- a/.github/workflows/push_readthedocs.yml
+++ b/.github/workflows/push_readthedocs.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build with sphinx
         run: devenv shell -- build-docs
 
+      - name: Set TMPDIR for mktemp
+        run: echo "TMPDIR=/tmp" >> $GITHUB_ENV
+
       - name: Pushes to another repository
         if: github.event_name == 'push' || github.event_name == 'release'
         uses: cpina/github-action-push-to-another-repository@main

--- a/.github/workflows/push_readthedocs.yml
+++ b/.github/workflows/push_readthedocs.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [develop, master]
   push:
-    branches: [develop, master, trigger-doc]
+    branches: [develop, master]
   release:
     types: [published]
 


### PR DESCRIPTION
The new environment (with Nix) doesn’t expose TMPDIR the way the action expects.
Adding the TMPDIR restores compatibility.

Doc is back: https://dscc-admin-ch.github.io/lomas-docs/develop/en/lomas_client.libraries.html#module-lomas_client.libraries.smartnoise_sql