### PR TITLE
Enable opendp polars pipeline in client for archives

### DIFF
--- a/client/lomas_client/client.py
+++ b/client/lomas_client/client.py
@@ -6,7 +6,7 @@ import pandas as pd
 import polars as pl
 from fastapi import status
 from opendp.mod import enable_features
-from opendp_logger import enable_logging, make_load_json
+from opendp_logger import enable_logging
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from pydantic import ValidationError
 
@@ -23,16 +23,14 @@ from lomas_client.models.config import ClientConfig
 from lomas_client.utils import raise_error, validate_model_response_direct
 from lomas_core.constants import DPLibraries
 from lomas_core.instrumentation import init_telemetry
-from lomas_core.models.requests import (
-    GetDummyDataset,
-    LomasRequestModel,
-)
+from lomas_core.models.requests import GetDummyDataset, LomasRequestModel, OpenDPQueryModel
 from lomas_core.models.responses import (
     DummyDsResponse,
     InitialBudgetResponse,
     RemainingBudgetResponse,
     SpentBudgetResponse,
 )
+from lomas_core.opendp_utils import reconstruct_measurement_pipeline
 
 # Opendp_logger
 enable_logging()
@@ -234,8 +232,10 @@ class Client:
                         else:
                             query["response"]["result"] = pd.DataFrame(res)
                     case DPLibraries.OPENDP:
-                        opdp_query = make_load_json(query["client_input"]["opendp_json"])
-                        query["client_input"]["opendp_json"] = opdp_query
+                        query_json = OpenDPQueryModel.model_validate(query["client_input"])
+                        query["client_input"]["opendp_json"] = reconstruct_measurement_pipeline(
+                            query_json, self.get_dataset_metadata()
+                        )
                     case DPLibraries.DIFFPRIVLIB:
                         model = base64.b64decode(query["response"]["result"]["model"])
                         query["response"]["result"]["model"] = pickle.loads(model)

--- a/client/lomas_client/libraries/opendp.py
+++ b/client/lomas_client/libraries/opendp.py
@@ -5,6 +5,7 @@ from lomas_client.constants import DUMMY_NB_ROWS, DUMMY_SEED
 from lomas_client.http_client import LomasHttpClient
 from lomas_client.utils import validate_model_response
 from lomas_core.constants import OpenDpMechanism, OpenDpPipelineType
+from lomas_core.error_handler import InvalidQueryException
 from lomas_core.models.requests import (
     OpenDPDummyQueryModel,
     OpenDPQueryModel,
@@ -58,7 +59,7 @@ class OpenDPClient:
             body_json["opendp_json"] = opendp_pipeline.serialize(format="json")
             body_json["pipeline_type"] = OpenDpPipelineType.POLARS
         else:
-            raise TypeError(
+            raise InvalidQueryException(
                 f"Opendp_pipeline must either of type Measurement or LazyFrame, found {type(opendp_pipeline)}"
             )
 

--- a/client/lomas_client/libraries/opendp.py
+++ b/client/lomas_client/libraries/opendp.py
@@ -4,7 +4,7 @@ import polars as pl
 from lomas_client.constants import DUMMY_NB_ROWS, DUMMY_SEED
 from lomas_client.http_client import LomasHttpClient
 from lomas_client.utils import validate_model_response
-from lomas_core.constants import OpenDpMechanism
+from lomas_core.constants import OpenDpMechanism, OpenDpPipelineType
 from lomas_core.models.requests import (
     OpenDPDummyQueryModel,
     OpenDPQueryModel,
@@ -53,10 +53,10 @@ class OpenDPClient:
 
         if isinstance(opendp_pipeline, dp.Measurement):
             body_json["opendp_json"] = opendp_pipeline.to_json()
-            body_json["pipeline_type"] = "legacy"
+            body_json["pipeline_type"] = OpenDpPipelineType.LEGACY
         elif isinstance(opendp_pipeline, pl.LazyFrame):
             body_json["opendp_json"] = opendp_pipeline.serialize(format="json")
-            body_json["pipeline_type"] = "polars"
+            body_json["pipeline_type"] = OpenDpPipelineType.POLARS
         else:
             raise TypeError(
                 f"Opendp_pipeline must either of type Measurement or LazyFrame, found {type(opendp_pipeline)}"

--- a/client/lomas_client/tests/test_integrations.py
+++ b/client/lomas_client/tests/test_integrations.py
@@ -135,6 +135,7 @@ def test_oauth2_demo(kc, demo_setup) -> None:
     prev_queries = client.get_previous_queries()
     assert len(prev_queries) == 1
     assert prev_queries[0]["dataset_name"] == "TITANIC"
+    assert prev_queries[0]["dp_library"] == "smartnoise_sql"
 
 
 def test_demo_diffprivlib(kc, demo_setup) -> None:
@@ -202,6 +203,22 @@ def test_demo_diffprivlib(kc, demo_setup) -> None:
     assert len(predictions) == 2
     assert predictions == pytest.approx([20, 20], abs=20)
 
+    prev_queries = client.get_previous_queries()
+    assert len(prev_queries) == 1
+    assert prev_queries[0]["dataset_name"] == "PENGUIN"
+    assert prev_queries[0]["dp_library"] == "diffprivlib"
+    returned_model = prev_queries[0]["response"]["result"]["model"]
+    predictions = returned_model.predict(
+        pd.DataFrame(
+            {
+                "bill_length_mm": [bill_length_meta["lower"], bill_length_meta["upper"]],
+            }
+        )
+    )
+
+    assert len(predictions) == 2
+    assert predictions == pytest.approx([20, 20], abs=20)
+
 
 @pytest.mark.long
 @pytest.mark.filterwarnings(
@@ -232,6 +249,14 @@ def test_demo_smartnoise_synth(kc, demo_setup) -> None:
         assert res_df.flipper_length_mm.mean() == pytest.approx(200, 0.25)
         assert res_df.body_mass_g.min() >= 5000
 
+    prev_queries = client.get_previous_queries()
+    assert len(prev_queries) == 1
+    assert prev_queries[0]["dataset_name"] == "PENGUIN"
+    assert prev_queries[0]["dp_library"] == "smartnoise_synth"
+    response_archives = prev_queries[0]["response"]
+    assert response_archives["epsilon"] == 1.0
+    assert response_archives["delta"] >= 0.0
+
 
 def test_demo_opendp_polars(kc, demo_setup) -> None:
     user_name = "Dr.FSO"
@@ -254,3 +279,13 @@ def test_demo_opendp_polars(kc, demo_setup) -> None:
     assert isinstance(query_res.result, OpenDPPolarsQueryResult)
     df_polar = query_res.result.value
     assert df_polar.shape == (1, 1)
+
+    prev_queries = client.get_previous_queries()
+    assert len(prev_queries) == 1
+    assert prev_queries[0]["dataset_name"] == "FSO_INCOME_SYNTHETIC"
+    assert prev_queries[0]["dp_library"] == "opendp"
+    assert prev_queries[0]["client_input"]["pipeline_type"] == "polars"
+    assert prev_queries[0]["client_input"]["mechanism"] == "laplace"
+    response_archives = prev_queries[0]["response"]
+    assert response_archives["epsilon"] >= 1.0
+    assert response_archives["delta"] >= 0.0

--- a/core/lomas_core/constants.py
+++ b/core/lomas_core/constants.py
@@ -1,5 +1,7 @@
 from enum import StrEnum
 
+from opendp import measures as ms, typing as tp
+
 # Server error messages
 INTERNAL_SERVER_ERROR = "Internal server error. Please contact the administrator of this service."
 
@@ -27,6 +29,21 @@ class OpenDpPipelineType(StrEnum):
 
     LEGACY = "legacy"
     POLARS = "polars"
+
+
+OPENDP_OUTPUT_MEASURE: dict[OpenDpMechanism, tp.Measure] = {
+    OpenDpMechanism.LAPLACE: ms.max_divergence(),
+    OpenDpMechanism.GAUSSIAN: ms.zero_concentrated_divergence(),
+}
+
+OPENDP_TYPE_MAPPING = {
+    "int32": tp.i32,
+    "float32": tp.f32,
+    "int64": tp.i64,
+    "float64": tp.f64,
+    "string": tp.String,
+    "boolean": bool,
+}
 
 
 # Smartnoise synth

--- a/core/lomas_core/opendp_utils.py
+++ b/core/lomas_core/opendp_utils.py
@@ -1,0 +1,244 @@
+import io
+import re
+
+import opendp as dp
+import polars as pl
+from opendp_logger import make_load_json
+
+from lomas_core.constants import OPENDP_OUTPUT_MEASURE, OPENDP_TYPE_MAPPING, OpenDpPipelineType
+from lomas_core.error_handler import InternalServerException, InvalidQueryException
+from lomas_core.models.constants import MetadataColumnType
+from lomas_core.models.requests import OpenDPQueryModel
+
+
+def get_raw_lf_domain(metadata_dict: dict) -> dp.mod.Domain:
+    """
+    Builds the "raw" lf domain from the metadata.
+
+    The domain in considered "raw" because it does not contain any margin.
+    The domain is built by putting together series domains from each column.
+    """
+    series_domains = []
+    # Series domains
+    for name, series_info in metadata_dict["columns"].items():
+        series_bounds = None
+        if series_info["type"] in [MetadataColumnType.FLOAT, MetadataColumnType.INT]:
+            series_type = f"{series_info['type']}{series_info['precision']}"
+            if hasattr(series_info, "lower") and hasattr(series_info, "upper"):
+                series_bounds = (series_info["lower"], series_info["upper"])
+        # TODO 392: release opendp 0.12 (adapt with type date)
+        elif series_info["type"] == MetadataColumnType.DATETIME:
+            series_type = MetadataColumnType.STRING
+        else:
+            series_type = series_info["type"]
+
+        if series_type not in OPENDP_TYPE_MAPPING:
+            # For valid metadata, only datetime would fail here
+            raise InvalidQueryException(
+                f"Column type {series_type} not supported by OpenDP. "
+                f"Type must be in {OPENDP_TYPE_MAPPING.keys()}"
+            )
+
+        # Note: Same as using option_domain (at least how I understand it)
+        series_nullable = (
+            series_info["nullable_proportion"] > 0.0 and series_type != MetadataColumnType.STRING
+        )
+        series_type = OPENDP_TYPE_MAPPING[series_type]
+
+        series_domain = dp.domains.series_domain(
+            name,
+            dp.domains.atom_domain(T=series_type, nullable=series_nullable, bounds=series_bounds),
+        )
+        series_domains.append(series_domain)
+
+    # Build domain from series domain
+    raw_lf_domain = dp.domains.lazyframe_domain(series_domains)
+
+    return raw_lf_domain
+
+
+def add_global_margin(lf_domain: dp.mod.Domain, metadata: dict) -> dp.mod.Domain:
+    """Builds the "global" (by = []) margin from the metadata."""
+    lf_domain = dp.domains.with_margin(
+        lf_domain,
+        by=[],
+        public_info="keys",
+        max_partition_length=metadata["rows"],
+        # max_partition_contributions already managed in the input_distance
+    )
+    return lf_domain
+
+
+def extract_group_by_columns(plan: str) -> list:
+    """
+    Extract column names used in the BY operation from the plan string.
+
+    Parameters:
+    plan (str): The polars query plan as a string.
+    Returns:
+    list: A list of column names used in the BY operation.
+    """
+    # Regular expression to capture the content inside BY []
+    aggregate_by_pattern = r"AGGREGATE(?:.|\n)+?BY \[(.*?)\]"
+
+    # Find the part of the plan related to the GROUP BY clause
+    match = re.findall(aggregate_by_pattern, plan)
+
+    if len(match) == 1:
+        # Extract the columns part
+        columns_part = match[0]
+        # Find all column names inside col("...")
+        column_names = re.findall(r'col\("([^"]+)"\)', columns_part)
+        return column_names
+    if len(match) > 1:
+        raise InvalidQueryException(
+            "Your are trying to do multiple groupings. "
+            "This is currently not supported, please use one grouping"
+        )
+    return []
+
+
+def multiply_or_none(values: list[int | None]) -> int | None:
+    """
+    Multiply all values in the list, return None if any value is None.
+
+    Args:
+        values (list[Optional[int]]): A list of int or None
+
+    Returns:
+        None if any None in the list, multiplied values of list otherwise.
+    """
+    if any(v is None for v in values):
+        return None
+    result = 1
+    for v in (v for v in values if v is not None):
+        result *= v
+    return result
+
+
+def multiple_group_params(metadata: dict, by_config: list) -> dict:
+    """
+    Updates parameters for multiple-column grouping configuration.
+
+    Args:
+        metadata (dict): The metadata dictionary.
+        by_config (list): List of columns used for grouping.
+
+    Returns:
+        (dict) updated margin_params for the groupby
+    """
+    # Initialize values
+    max_partition_length = metadata["rows"]
+    max_num_partitions_l = []
+    max_influenced_partitions_l = []
+    max_partition_contributions_l = []
+
+    # Iterate through grouping columns
+    for column in by_config:
+        series_info = metadata["columns"][column]
+
+        # Update the max_partition_length
+        if series_info["max_partition_length"] is not None:
+            max_partition_length = min(max_partition_length, series_info["max_partition_length"])
+
+        # Get all groupby parameters in a list
+        max_num_partitions_l.append(series_info.get("cardinality", None))
+        max_influenced_partitions_l.append(series_info.get("max_influenced_partitions", None))
+        max_partition_contributions_l.append(series_info.get("max_partition_contributions", None))
+
+    # We multiply the cardinality, max_influenced_partitions and max_partition_contributions
+    # of each groupby column. If any None, then no margin.
+    max_num_partitions = multiply_or_none(max_num_partitions_l)
+    max_influenced_partitions = multiply_or_none(max_influenced_partitions_l)
+    max_partition_contributions = multiply_or_none(max_partition_contributions_l)
+
+    # Make margin
+    margin_params = {}
+    margin_params["max_partition_length"] = max_partition_length
+    if max_num_partitions:
+        margin_params["max_num_partitions"] = max_num_partitions
+
+    # If max_influenced_partitions > max_ids: then max_influenced_partitions = max_ids
+    if max_influenced_partitions:
+        max_influenced_partitions = min(metadata["max_ids"], max_influenced_partitions)
+        margin_params["max_influenced_partitions"] = max_influenced_partitions
+
+    # If max_partition_contributions > max_ids: then max_partition_contributions = max_ids
+    if max_partition_contributions:
+        max_partition_contributions = min(metadata["max_ids"], max_partition_contributions)
+        margin_params["max_partition_contributions"] = max_partition_contributions
+
+    return margin_params
+
+
+def get_lf_domain(metadata_dict: dict, plan: pl.LazyFrame) -> dp.mod.Domain:
+    """
+    Returns the OpenDP LazyFrame domain given a metadata dictionary.
+
+    Args:
+        metadata_dict (dict): The metadata dictionary
+        plan (LazyFrame): The polars query plan as a Polars LazyFrame
+    Raises:
+        Exception: If there is missing information in the metadata.
+    Returns:
+        dp.mod.Domain: The OpenDP domain for the metadata.
+    """
+    # Get raw lf domain (without margins)
+    raw_lf_domain = get_raw_lf_domain(metadata_dict)
+
+    # Add global margin to domain (for by=[])
+    lf_domain = add_global_margin(raw_lf_domain, metadata_dict)
+
+    # If grouping in the query, we update the margin params
+    by_config = extract_group_by_columns(plan.explain())
+    if len(by_config) >= 1:
+        margin_params = multiple_group_params(metadata_dict, by_config)
+        # TODO 323: Multiple margins?
+        # What if two group_by's in one query?
+        # Update margin with group_margin
+        lf_domain = dp.domains.with_margin(
+            lf_domain,
+            by=by_config,
+            public_info="keys",
+            **margin_params,
+        )
+    return lf_domain
+
+
+def reconstruct_measurement_pipeline(query_json: OpenDPQueryModel, metadata: dict) -> dp.Measurement:
+    """Reconstruct OpenDP pipeline from json representation.
+
+    Args:
+        query_json (BaseModel): The JSON request object for the query.
+        metadata (dict): The dataset metadata dictionary.\
+            Only used for polars pipelines.
+
+    Raises:
+        InvalidQueryException: If the pipeline is not a measurement or\
+            the pipeline type is not supported.
+
+    Returns:
+        dp.Measurement: The reconstructed pipeline.
+    """
+    # Reconstruct pipeline
+    if query_json.pipeline_type == OpenDpPipelineType.LEGACY:
+        opendp_pipe = make_load_json(query_json.opendp_json)
+    elif query_json.pipeline_type == OpenDpPipelineType.POLARS:
+        plan = pl.LazyFrame.deserialize(io.StringIO(query_json.opendp_json), format="json")
+
+        assert query_json.mechanism is not None
+        output_measure = OPENDP_OUTPUT_MEASURE[query_json.mechanism]
+
+        lf_domain = get_lf_domain(metadata, plan)
+
+        opendp_pipe = dp.measurements.make_private_lazyframe(
+            lf_domain,
+            dp.metrics.symmetric_distance(),
+            output_measure,
+            plan,
+            threshold=100,
+        )
+    else:
+        raise InternalServerException(f"Unsupported OpenDP pipeline type: {query_json.pipeline_type}")
+
+    return opendp_pipe

--- a/server/lomas_server/constants.py
+++ b/server/lomas_server/constants.py
@@ -1,10 +1,6 @@
 import string
 from enum import StrEnum
 
-from opendp import measures as ms, typing as tp
-
-from lomas_core.constants import OpenDpMechanism
-
 # Misc
 # -----------------------------------------------------------------------------
 
@@ -83,18 +79,3 @@ class OpenDPDatasetInputMetric(StrEnum):
     HAMMING_DISTANCE = "HammingDistance"
 
     INT_DISTANCE = "u32"  # opendp type for distance between datasets
-
-
-OPENDP_TYPE_MAPPING = {
-    "int32": tp.i32,
-    "float32": tp.f32,
-    "int64": tp.i64,
-    "float64": tp.f64,
-    "string": tp.String,
-    "boolean": bool,
-}
-
-OPENDP_OUTPUT_MEASURE: dict[OpenDpMechanism, tp.Measure] = {
-    OpenDpMechanism.LAPLACE: ms.max_divergence(),
-    OpenDpMechanism.GAUSSIAN: ms.zero_concentrated_divergence(),
-}

--- a/server/lomas_server/dp_queries/dp_libraries/opendp.py
+++ b/server/lomas_server/dp_queries/dp_libraries/opendp.py
@@ -1,14 +1,11 @@
-import io
 import logging
 import os
-import re
 
 import opendp as dp
 import polars as pl
 from opendp._lib import lib_path
 from opendp.metrics import metric_distance_type, metric_type
 from opendp.mod import enable_features
-from opendp_logger import make_load_json
 
 from lomas_core.constants import DPLibraries
 from lomas_core.error_handler import (
@@ -17,185 +14,13 @@ from lomas_core.error_handler import (
     InvalidQueryException,
 )
 from lomas_core.models.constants import MetadataColumnType, OpenDPFeatures
-from lomas_core.models.requests import (
-    OpenDPQueryModel,
-    OpenDPRequestModel,
-)
+from lomas_core.models.requests import OpenDPQueryModel, OpenDPRequestModel
 from lomas_core.models.responses import OpenDPPolarsQueryResult, OpenDPQueryResult
+from lomas_core.opendp_utils import reconstruct_measurement_pipeline
 from lomas_server.admin_database.admin_database import AdminDatabase
-from lomas_server.constants import (
-    OPENDP_OUTPUT_MEASURE,
-    OPENDP_TYPE_MAPPING,
-    OpenDPDatasetInputMetric,
-    OpenDPMeasurement,
-)
+from lomas_server.constants import OpenDPDatasetInputMetric, OpenDPMeasurement
 from lomas_server.data_connector.data_connector import DataConnector
 from lomas_server.dp_queries.dp_querier import DPQuerier
-
-
-def get_lf_domain(metadata_dict: dict, plan: pl.LazyFrame) -> dp.mod.Domain:
-    """
-    Returns the OpenDP LazyFrame domain given a metadata dictionary.
-
-    Args:
-        metadata_dict (dict): The metadata dictionary
-        plan (LazyFrame): The polars query plan as a Polars LazyFrame
-    Raises:
-        Exception: If there is missing information in the metadata.
-    Returns:
-        dp.mod.Domain: The OpenDP domain for the metadata.
-    """
-    # Get raw lf domain (without margins)
-    raw_lf_domain = get_raw_lf_domain(metadata_dict)
-
-    # Add global margin to domain (for by=[])
-    lf_domain = add_global_margin(raw_lf_domain, metadata_dict)
-
-    # If grouping in the query, we update the margin params
-    by_config = extract_group_by_columns(plan.explain())
-    if len(by_config) >= 1:
-        margin_params = multiple_group_params(metadata_dict, by_config)
-        # TODO 323: Multiple margins?
-        # What if two group_by's in one query?
-        # Update margin with group_margin
-        lf_domain = dp.domains.with_margin(
-            lf_domain,
-            by=by_config,
-            public_info="keys",
-            **margin_params,
-        )
-    return lf_domain
-
-
-def get_raw_lf_domain(metadata_dict: dict) -> dp.mod.Domain:
-    """
-    Builds the "raw" lf domain from the metadata.
-
-    The domain in considered "raw" because it does not contain any margin.
-    The domain is built by putting together series domains from each column.
-    """
-    series_domains = []
-    # Series domains
-    for name, series_info in metadata_dict["columns"].items():
-        series_bounds = None
-        if series_info["type"] in [MetadataColumnType.FLOAT, MetadataColumnType.INT]:
-            series_type = f"{series_info['type']}{series_info['precision']}"
-            if hasattr(series_info, "lower") and hasattr(series_info, "upper"):
-                series_bounds = (series_info["lower"], series_info["upper"])
-        # TODO 392: release opendp 0.12 (adapt with type date)
-        elif series_info["type"] == MetadataColumnType.DATETIME:
-            series_type = MetadataColumnType.STRING
-        else:
-            series_type = series_info["type"]
-
-        if series_type not in OPENDP_TYPE_MAPPING:
-            # For valid metadata, only datetime would fail here
-            raise InvalidQueryException(
-                f"Column type {series_type} not supported by OpenDP. "
-                f"Type must be in {OPENDP_TYPE_MAPPING.keys()}"
-            )
-
-        # Note: Same as using option_domain (at least how I understand it)
-        series_nullable = (
-            series_info["nullable_proportion"] > 0.0 and series_type != MetadataColumnType.STRING
-        )
-        series_type = OPENDP_TYPE_MAPPING[series_type]
-
-        series_domain = dp.domains.series_domain(
-            name,
-            dp.domains.atom_domain(T=series_type, nullable=series_nullable, bounds=series_bounds),
-        )
-        series_domains.append(series_domain)
-
-    # Build domain from series domain
-    raw_lf_domain = dp.domains.lazyframe_domain(series_domains)
-
-    return raw_lf_domain
-
-
-def add_global_margin(lf_domain: dp.mod.Domain, metadata: dict) -> dp.mod.Domain:
-    """Builds the "global" (by = []) margin from the metadata."""
-    lf_domain = dp.domains.with_margin(
-        lf_domain,
-        by=[],
-        public_info="keys",
-        max_partition_length=metadata["rows"],
-        # max_partition_contributions already managed in the input_distance
-    )
-    return lf_domain
-
-
-def multiply_or_none(values: list[int | None]) -> int | None:
-    """
-    Multiply all values in the list, return None if any value is None.
-
-    Args:
-        values (list[Optional[int]]): A list of int or None
-
-    Returns:
-        None if any None in the list, multiplied values of list otherwise.
-    """
-    if any(v is None for v in values):
-        return None
-    result = 1
-    for v in (v for v in values if v is not None):
-        result *= v
-    return result
-
-
-def multiple_group_params(metadata: dict, by_config: list) -> dict:
-    """
-    Updates parameters for multiple-column grouping configuration.
-
-    Args:
-        metadata (dict): The metadata dictionary.
-        by_config (list): List of columns used for grouping.
-
-    Returns:
-        (dict) updated margin_params for the groupby
-    """
-    # Initialize values
-    max_partition_length = metadata["rows"]
-    max_num_partitions_l = []
-    max_influenced_partitions_l = []
-    max_partition_contributions_l = []
-
-    # Iterate through grouping columns
-    for column in by_config:
-        series_info = metadata["columns"][column]
-
-        # Update the max_partition_length
-        if series_info["max_partition_length"] is not None:
-            max_partition_length = min(max_partition_length, series_info["max_partition_length"])
-
-        # Get all groupby parameters in a list
-        max_num_partitions_l.append(series_info.get("cardinality", None))
-        max_influenced_partitions_l.append(series_info.get("max_influenced_partitions", None))
-        max_partition_contributions_l.append(series_info.get("max_partition_contributions", None))
-
-    # We multiply the cardinality, max_influenced_partitions and max_partition_contributions
-    # of each groupby column. If any None, then no margin.
-    max_num_partitions = multiply_or_none(max_num_partitions_l)
-    max_influenced_partitions = multiply_or_none(max_influenced_partitions_l)
-    max_partition_contributions = multiply_or_none(max_partition_contributions_l)
-
-    # Make margin
-    margin_params = {}
-    margin_params["max_partition_length"] = max_partition_length
-    if max_num_partitions:
-        margin_params["max_num_partitions"] = max_num_partitions
-
-    # If max_influenced_partitions > max_ids: then max_influenced_partitions = max_ids
-    if max_influenced_partitions:
-        max_influenced_partitions = min(metadata["max_ids"], max_influenced_partitions)
-        margin_params["max_influenced_partitions"] = max_influenced_partitions
-
-    # If max_partition_contributions > max_ids: then max_partition_contributions = max_ids
-    if max_partition_contributions:
-        max_partition_contributions = min(metadata["max_ids"], max_partition_contributions)
-        margin_params["max_partition_contributions"] = max_partition_contributions
-
-    return margin_params
 
 
 class OpenDPQuerier(DPQuerier[OpenDPRequestModel, OpenDPQueryModel, OpenDPQueryResult]):
@@ -237,6 +62,7 @@ class OpenDPQuerier(DPQuerier[OpenDPRequestModel, OpenDPQueryModel, OpenDPQueryR
                 is the epsilon cost, the second value is the delta value.
         """
         opendp_pipe = reconstruct_measurement_pipeline(query_json, self.metadata)
+        validate_measurement_pipeline(opendp_pipe)
 
         measurement_type = get_output_measure(opendp_pipe)
         # https://docs.opendp.org/en/stable/user/combinators.html#measure-casting
@@ -285,6 +111,7 @@ class OpenDPQuerier(DPQuerier[OpenDPRequestModel, OpenDPQueryModel, OpenDPQueryR
             (Union[List, int, float]) query result
         """
         opendp_pipe = reconstruct_measurement_pipeline(query_json, self.metadata)
+        validate_measurement_pipeline(opendp_pipe)
 
         if query_json.pipeline_type == "legacy":
             input_data = self.data_connector.get_pandas_df().to_csv(header=False, index=False)
@@ -365,76 +192,17 @@ def has_dataset_input_metric(pipeline: dp.Measurement) -> None:
         raise InvalidQueryException(e)
 
 
-def extract_group_by_columns(plan: str) -> list:
-    """
-    Extract column names used in the BY operation from the plan string.
-
-    Parameters:
-    plan (str): The polars query plan as a string.
-    Returns:
-    list: A list of column names used in the BY operation.
-    """
-    # Regular expression to capture the content inside BY []
-    aggregate_by_pattern = r"AGGREGATE(?:.|\n)+?BY \[(.*?)\]"
-
-    # Find the part of the plan related to the GROUP BY clause
-    match = re.findall(aggregate_by_pattern, plan)
-
-    if len(match) == 1:
-        # Extract the columns part
-        columns_part = match[0]
-        # Find all column names inside col("...")
-        column_names = re.findall(r'col\("([^"]+)"\)', columns_part)
-        return column_names
-    if len(match) > 1:
-        raise InvalidQueryException(
-            "Your are trying to do multiple groupings. "
-            "This is currently not supported, please use one grouping"
-        )
-    return []
-
-
-def reconstruct_measurement_pipeline(query_json: OpenDPQueryModel, metadata: dict) -> dp.Measurement:
-    """Reconstruct OpenDP pipeline from json representation.
+def validate_measurement_pipeline(opendp_pipe: dp.Measurement) -> None:
+    """Verify that the pipeline is safe and valid.
 
     Args:
-        query_json (BaseModel): The JSON request object for the query.
-        metadata (dict): The dataset metadata dictionary.\
-            Only used for polars pipelines.
+        pipeline (dp.Measurement): The pipeline to check.
 
     Raises:
-        InvalidQueryException: If the pipeline is not a measurement or\
-            the pipeline type is not supported.
-
-    Returns:
-        dp.Measurement: The reconstructed pipeline.
+        InvalidQueryException: If the pipeline does not meet the requirements.
     """
-    # Reconstruct pipeline
-    if query_json.pipeline_type == "legacy":
-        opendp_pipe = make_load_json(query_json.opendp_json)
-    elif query_json.pipeline_type == "polars":
-        plan = pl.LazyFrame.deserialize(io.StringIO(query_json.opendp_json), format="json")
-
-        assert query_json.mechanism is not None
-        output_measure = OPENDP_OUTPUT_MEASURE[query_json.mechanism]
-
-        lf_domain = get_lf_domain(metadata, plan)
-
-        opendp_pipe = dp.measurements.make_private_lazyframe(
-            lf_domain,
-            dp.metrics.symmetric_distance(),
-            output_measure,
-            plan,
-            threshold=100,
-        )
-    else:
-        raise InternalServerException(f"Unsupported OpenDP pipeline type: {query_json.pipeline_type}")
-
-    # Verify that the pipeline is safe and valid
     is_measurement(opendp_pipe)
     has_dataset_input_metric(opendp_pipe)
-
-    return opendp_pipe
 
 
 def get_output_measure(opendp_pipe: dp.Measurement) -> str:

--- a/server/lomas_server/dp_queries/dp_libraries/opendp.py
+++ b/server/lomas_server/dp_queries/dp_libraries/opendp.py
@@ -7,7 +7,7 @@ from opendp._lib import lib_path
 from opendp.metrics import metric_distance_type, metric_type
 from opendp.mod import enable_features
 
-from lomas_core.constants import DPLibraries
+from lomas_core.constants import DPLibraries, OpenDpPipelineType
 from lomas_core.error_handler import (
     ExternalLibraryException,
     InternalServerException,
@@ -113,9 +113,9 @@ class OpenDPQuerier(DPQuerier[OpenDPRequestModel, OpenDPQueryModel, OpenDPQueryR
         opendp_pipe = reconstruct_measurement_pipeline(query_json, self.metadata)
         validate_measurement_pipeline(opendp_pipe)
 
-        if query_json.pipeline_type == "legacy":
+        if query_json.pipeline_type == OpenDpPipelineType.LEGACY:
             input_data = self.data_connector.get_pandas_df().to_csv(header=False, index=False)
-        elif query_json.pipeline_type == "polars":
+        elif query_json.pipeline_type == OpenDpPipelineType.POLARS:
             input_data = self.data_connector.get_polars_lf()
             # OpenDP does not allow None on string columns
 

--- a/server/lomas_server/tests/test_api_opendp_polars.py
+++ b/server/lomas_server/tests/test_api_opendp_polars.py
@@ -8,17 +8,10 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from opendp import measures as ms
 
-from lomas_core.error_handler import (
-    InvalidQueryException,
-)
+from lomas_core.error_handler import InvalidQueryException
 from lomas_core.models.collections import Metadata
-from lomas_core.models.constants import (
-    DUMMY_NB_ROWS,
-    DUMMY_SEED,
-)
-from lomas_core.models.exceptions import (
-    InvalidQueryExceptionModel,
-)
+from lomas_core.models.constants import DUMMY_NB_ROWS, DUMMY_SEED
+from lomas_core.models.exceptions import InvalidQueryExceptionModel
 from lomas_core.models.requests_examples import (
     OPENDP_POLARS_PIPELINE,
     OPENDP_POLARS_PIPELINE_COVID,
@@ -30,11 +23,8 @@ from lomas_core.models.responses import (
     OpenDPPolarsQueryResult,
     QueryResponse,
 )
+from lomas_core.opendp_utils import get_lf_domain, multiple_group_params
 from lomas_server.app import app
-from lomas_server.dp_queries.dp_libraries.opendp import (
-    get_lf_domain,
-    multiple_group_params,
-)
 from lomas_server.tests.test_api_root import TestSetupRootAPIEndpoint
 from lomas_server.tests.utils import submit_job_wait
 


### PR DESCRIPTION
Before:
-  can only reconstruct legacy opendp archives
- error if any archive with opendp polars

Now: 
- can reconstruct both

Diff: Move reconstruction of opendp pipeline in core instead of server.