### PR TITLE
Move jobs to db

### DIFF
--- a/server/lomas_server/admin_database/admin_database.py
+++ b/server/lomas_server/admin_database/admin_database.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import wraps
 from typing import Concatenate, TypeVar
+from uuid import UUID
 
 from csvw_eo.metadata_structure import TableMetadata
 from pydantic import (
@@ -15,9 +16,12 @@ from lomas_core.error_handler import (
     UnauthorizedAccessException,
 )
 from lomas_core.models.collections import DSInfo
+from lomas_core.models.constants import get_lomas_logger
 from lomas_core.models.requests import LomasRequestModel, model_input_to_lib
-from lomas_core.models.responses import QueryResponse
+from lomas_core.models.responses import Job, QueryResponse
 from lomas_server.admin_database.constants import BudgetDBKey
+
+logger = get_lomas_logger(__name__)
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -137,13 +141,57 @@ class AdminDatabase(ABC, BaseModel):
     @abstractmethod
     def does_dataset_exist(self, dataset_name: str) -> bool:
         """
-        Checks if dataset exist in the database.
+        Checks if dataset exists in the database.
 
         Args:
             dataset_name (str): name of the dataset to check
 
         Returns:
             bool: True if the dataset exists, False otherwise.
+        """
+
+    @abstractmethod
+    def does_job_exist(self, uid: UUID) -> bool:
+        """Returns true only if the job exists.
+
+        Args:
+            uid (UUID): The uid of the job.
+
+        Returns:
+            bool: True only if the job exists
+        """
+
+    @abstractmethod
+    def get_job_for_user(self, user_name: str, uid: UUID) -> Job:
+        """
+        Checks if jobs exists and if user owns job before returning the job.
+
+        Args:
+            user_name (str): The name of the user who must own the job.
+            uid (UUID): The uid of the job.
+
+        Returns:
+            Job: The job, only if it exists and the user owns it.
+        """
+
+    @abstractmethod
+    def put_job(self, job: Job) -> None:
+        """
+        Puts the job in the database.
+
+        Args:
+            job (Job): The job to put in the database.
+        """
+
+    @abstractmethod
+    def update_job(self, updated_job: Job) -> None:
+        """
+        Updates the job.
+
+        All fields are taken from updated_job, except those that are None.
+
+        Args:
+            updated_job (Job): The updated job
         """
 
     @abstractmethod

--- a/server/lomas_server/admin_database/constants.py
+++ b/server/lomas_server/admin_database/constants.py
@@ -16,6 +16,7 @@ class MiscDBKeys(StrEnum):
 
     BOOTSTRAP_DISABLED = "bootstrap_disabled"
     BOOTSTRAP = "bootstrap"
+    JOBS = "jobs"
 
 
 class BudgetDBKey(StrEnum):

--- a/server/lomas_server/admin_database/local_database.py
+++ b/server/lomas_server/admin_database/local_database.py
@@ -5,15 +5,20 @@ import sys
 from pathlib import Path
 from tempfile import SpooledTemporaryFile
 from typing import Any, BinaryIO, Self
+from uuid import UUID
 
 import boto3
 import yaml
 from csvw_eo.metadata_structure import TableMetadata
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile
 from filelock import SoftFileLock
 from pydantic import HttpUrl
+from starlette import status
 
-from lomas_core.error_handler import InternalServerException
+from lomas_core.error_handler import (
+    InternalServerException,
+    UnauthorizedAccessException,
+)
 from lomas_core.models.collections import (
     DatasetOfUser,
     DatasetsCollection,
@@ -26,7 +31,7 @@ from lomas_core.models.collections import (
 )
 from lomas_core.models.constants import PrivateDatabaseType, get_lomas_logger
 from lomas_core.models.requests import LomasRequestModel
-from lomas_core.models.responses import QueryResponse
+from lomas_core.models.responses import Job, QueryResponse
 from lomas_server.admin_database.admin_database import (
     AdminDatabase,
     dataset_must_exist,
@@ -61,17 +66,77 @@ class LocalAdminDatabase(AdminDatabase):
     """Database accepts existing path or new (creatable) path."""
 
     @lock
-    def model_post_init(self, _: Any, /) -> None:
-        # create the file if it doesn't exists yet (makes open with flag='r' safe)
-        shelve.open(self.path).close()
+    def model_post_init(self, _: Any) -> None:
+        self.set_defaults()
 
     @override
     @lock
     def wipe(self) -> None:
         if (p := Path(self.path)).exists():
             p.unlink()
-        # Recreate file to make open with flag="r" safe
-        shelve.open(self.path).close()
+        self.set_defaults()
+
+    def set_defaults(self) -> None:
+        """Sets the default values for all collections in the database."""
+        # create the file if it doesn't exists yet (makes open with flag='r' safe)
+        with shelve.open(self.path, writeback=True) as db:
+            # Initialize to empty dicts by default
+
+            db.setdefault(TK.USERS, {})
+            db.setdefault(TK.DATASETS, {})
+            db.setdefault(TK.METADATA, {})
+            db.setdefault(TK.ARCHIVE, [])  # array
+            db.setdefault(TK.MISC_KEYS, {})
+            db[TK.MISC_KEYS].setdefault(MiscDBKeys.JOBS, {})
+
+    @override
+    @lock
+    def does_job_exist(self, uid: UUID) -> bool:
+        with shelve.open(self.path, flag="r") as db:
+            return uid in db[TK.MISC_KEYS][MiscDBKeys.JOBS].keys()
+
+    @override
+    @db_span("db.get_job", table="admin-db")
+    @lock
+    def get_job_for_user(self, user_name: str, uid: UUID) -> Job:
+        ADMINDB_QUERY_COUNTER.add(1, {"operation": "get_job"})
+
+        with shelve.open(self.path, flag="r") as db:
+            # Check job exists
+            if uid not in db[TK.MISC_KEYS][MiscDBKeys.JOBS].keys():
+                message = f"Job {uid} does not exist."
+                logger.debug(f"Error 404 raised: {message}")
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
+
+            job = db[TK.MISC_KEYS][MiscDBKeys.JOBS][uid]
+
+            # Check user owns job
+            if job.requested_by != user_name:
+                raise UnauthorizedAccessException(
+                    f"User {user_name} does not have access to job with uid {uid}"
+                )
+
+            return job
+
+    @override
+    @db_span("db.put_job", table="admin-db")
+    @lock
+    def put_job(self, job: Job) -> None:
+        ADMINDB_QUERY_COUNTER.add(1, {"operation": "put_job"})
+        with shelve.open(self.path, writeback=True) as db:
+            db[TK.MISC_KEYS][MiscDBKeys.JOBS][job.uid] = job
+
+    @override
+    @lock
+    def update_job(self, updated_job: Job) -> None:
+        uid = updated_job.uid
+        with shelve.open(self.path, writeback=True) as db:
+            if uid not in db[TK.MISC_KEYS][MiscDBKeys.JOBS].keys():
+                raise InternalServerException(f"Cannot update job with uid {uid}: not in db.")
+            merged_job = db[TK.MISC_KEYS][MiscDBKeys.JOBS][uid].model_copy(
+                update=updated_job.model_dump(exclude_none=True), deep=True
+            )
+            db[TK.MISC_KEYS][MiscDBKeys.JOBS][uid] = merged_job
 
     @lock
     def load_users_collection(self, users: list[User]) -> None:
@@ -590,7 +655,8 @@ class LocalAdminDatabase(AdminDatabase):
     @lock
     def set_bootstrap(self, bootstrap: str) -> None:
         with shelve.open(self.path, writeback=True) as db:
-            db[TK.MISC_KEYS] = {MiscDBKeys.BOOTSTRAP_DISABLED: False, MiscDBKeys.BOOTSTRAP: bootstrap}
+            db[TK.MISC_KEYS][MiscDBKeys.BOOTSTRAP_DISABLED] = False
+            db[TK.MISC_KEYS][MiscDBKeys.BOOTSTRAP] = bootstrap
 
     @override
     @lock

--- a/server/lomas_server/app.py
+++ b/server/lomas_server/app.py
@@ -40,12 +40,10 @@ async def lifespan(lomas_app: FastAPI) -> AsyncGenerator[None]:
     # Load Config
     config = Config()
 
-    # Set some app state
-    lomas_app.state.jobs = {}
-
     # Load admin database
     try:
         logger.info("Loading admin database")
+
         lomas_app.state.admin_database = config.database
         if config.clean_admin_database:
             logger.warning(

--- a/server/lomas_server/routes/routes_admin.py
+++ b/server/lomas_server/routes/routes_admin.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from csvw_eo.datatypes import to_pandas_dtype
 from csvw_eo.make_dummy_from_metadata import make_dummy_from_metadata
 from csvw_eo.metadata_structure import TableMetadata
-from fastapi import APIRouter, Body, HTTPException, Request, Response, Security, UploadFile, status
+from fastapi import APIRouter, Body, Request, Response, Security, UploadFile, status
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from lomas_core.constants import Scopes
@@ -80,20 +80,18 @@ async def status_handler(
     Returns:
         Job: The Job model for this uid.
     """
-    jobs = request.app.state.jobs
-    if (job := jobs.get(str(uid))) is not None:
-        if job.requested_by != user_id.name:
-            raise UnauthorizedAccessException(f"{user_id.name} does not have access to job with uid {uid}.")
+    # Handles both exceptional cases
+    job = request.app.state.admin_database.get_job_for_user(user_id.name, uid)
 
-        if job.status == "failed":
-            response.status_code = job.status_code
+    if job.status == "failed":
+        response.status_code = job.status_code
 
-        if job.status == "complete":
-            # Delete completed job from state once returned to user.
-            del jobs[str(uid)]
+    # TODO: keep jobs as new archive collection?
+    # if job.status == "complete":
+    #     # Delete completed job from state once returned to user.
+    #     del jobs[str(uid)]
 
-        return job
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="This job does not exist.")
+    return job
 
 
 # Get server state

--- a/server/lomas_server/routes/utils.py
+++ b/server/lomas_server/routes/utils.py
@@ -29,6 +29,7 @@ from lomas_core.models.requests import (
     QueryModel,
 )
 from lomas_core.models.responses import CostResponse, Job, QueryResponse
+from lomas_server.admin_database.admin_database import AdminDatabase
 from lomas_server.auth.auth import authorize_user
 from lomas_server.data_connector.path_connector import PathConnector
 from lomas_server.data_connector.s3_connector import S3Connector
@@ -38,29 +39,35 @@ logger = get_lomas_logger(__name__)
 
 
 async def process_response(
-    queue: aio_pika.Queue, cls: type[QueryResponse | CostResponse], jobs: dict[UUID, Job]
+    queue: aio_pika.Queue, cls: type[QueryResponse | CostResponse], admin_database: AdminDatabase
 ) -> None:
     """Process responses queue into Jobs."""
     async with queue.iterator() as queue_iter:
         async for message in queue_iter:
             async with message.process(ignore_processed=True):
-                if message.correlation_id not in jobs:
+                if not admin_database.does_job_exist(UUID(message.correlation_id)):
                     await message.reject(requeue=True)
                 else:
                     await message.ack()
 
                     message_body = message.body.decode()
                     match message.headers:
-                        case {"type": "exception", "status_code": status_code}:
-                            jobs[
-                                message.correlation_id
-                            ].error = LomasServerExceptionTypeAdapter.validate_json(message_body)
-                            jobs[message.correlation_id].status = "failed"
-                            jobs[message.correlation_id].result = None
-                            jobs[message.correlation_id].status_code = status_code
+                        case {"type": "exception", "status_code": int() as status_code}:
+                            updated_job = Job(
+                                uid=UUID(message.correlation_id),
+                                status="failed",
+                                error=LomasServerExceptionTypeAdapter.validate_json(message_body),
+                                result=None,
+                                status_code=status_code,
+                            )
+                            admin_database.update_job(updated_job)
                         case _:
-                            jobs[message.correlation_id].result = cls.model_validate_json(message_body)
-                            jobs[message.correlation_id].status = "complete"
+                            updated_job = Job(
+                                uid=UUID(message.correlation_id),
+                                result=cls.model_validate_json(message_body),
+                                status="complete",
+                            )
+                            admin_database.update_job(updated_job)
 
 
 async def rabbitmq_connect_queue(
@@ -92,21 +99,25 @@ async def rabbitmq_ctx(app: FastAPI) -> AsyncIterator[None]:
     await channel.declare_queue("task_queue", durable=True)
     app.state.task_queue_channel = channel
     queue = await channel.declare_queue("task_response", durable=True)
-    tasks_response_task = asyncio.create_task(process_response(queue, QueryResponse, app.state.jobs))
+    tasks_response_task = asyncio.create_task(
+        process_response(queue, QueryResponse, app.state.admin_database)
+    )
     background_tasks.add(tasks_response_task)
     tasks_response_task.add_done_callback(background_tasks.discard)
 
     await channel.declare_queue("cost_queue", durable=True)
     app.state.cost_queue_channel = channel
     queue = await channel.declare_queue("cost_response", durable=True)
-    cost_response_task = asyncio.create_task(process_response(queue, CostResponse, app.state.jobs))
+    cost_response_task = asyncio.create_task(process_response(queue, CostResponse, app.state.admin_database))
     background_tasks.add(cost_response_task)
     cost_response_task.add_done_callback(background_tasks.discard)
 
     await channel.declare_queue("dummy_queue", durable=True)
     app.state.dummy_queue_channel = channel
     queue = await channel.declare_queue("dummy_response", durable=True)
-    dummy_response_task = asyncio.create_task(process_response(queue, QueryResponse, app.state.jobs))
+    dummy_response_task = asyncio.create_task(
+        process_response(queue, QueryResponse, app.state.admin_database)
+    )
     background_tasks.add(dummy_response_task)
     dummy_response_task.add_done_callback(background_tasks.discard)
 
@@ -291,7 +302,8 @@ async def handle_query_to_job(
 
     new_task = Job(requested_by=user_name)
 
-    app.state.jobs[str(new_task.uid)] = new_task
+    # app.state.jobs[str(new_task.uid)] = new_task
+    admin_database.put_job(new_task)
 
     await app.state.cost_queue_channel.default_exchange.publish(
         aio_pika.Message(

--- a/server/lomas_server/tests/utils.py
+++ b/server/lomas_server/tests/utils.py
@@ -24,6 +24,7 @@ def wait_for_job(client: httpx.Client, endpoint: str, headers: dict[str, str] | 
     """Periodically query the job endpoint sleeping in between until it completes / times-out."""
     for _ in sleeping_retry(120, error=False):
         job_query = client.get(endpoint, headers=headers).json()
+
         if job_query["status"] in {"complete", "failed"}:
             return Job.model_validate(job_query)
 


### PR DESCRIPTION
In the next few prs:
- use job collection for archives (avoid duplicates, archive is now a model)
- remove permission verifications from db code, remove safety checks decorators (does_user_exist) -> move this to caller. -> will reduce number of calls to db and reduce lock contention.